### PR TITLE
增加Yaf_View_Interface、Yaf_Route_Interface接口语法导出

### DIFF
--- a/tools/yaf.php
+++ b/tools/yaf.php
@@ -8,11 +8,19 @@
 */
 
 $classes = get_declared_classes();
+$interfaces = get_declared_interfaces();
+
 foreach ($classes as $key => $value) {
     if (strncasecmp($value, "Yaf_", 3)) {
         unset($classes[$key]);
     }
 }
+foreach ($interfaces as $key => $value) {
+    if (strncasecmp($value, "Yaf_", 3)) {
+        unset($interfaces[$key]);
+    }
+}
+$classes = array_merge($interfaces,$classes);
 
 echo "<?php\n";
 
@@ -20,24 +28,16 @@ foreach ($classes as $class_name) {
      $class = new ReflectionClass($class_name);
      $indent  = "";
 
-     if ($class->isFinal()) {
-         echo "final ";
-     }
-
-     if ($class->isAbstract()) {
-         echo "abstract ";
-     }
-
      if ($class->isInterface()) {
          echo "Interface ", $class_name;
      } else {
+        if ($class->isFinal()) {
+             echo "final ";
+         }
+        if ($class->isAbstract()) {
+             echo "abstract ";
+         }
          echo "class ", $class_name;
-     }
-
-     /* parent */
-     $parent = $class->getParentClass();
-     if ($parent) {
-         echo " extends ", $parent->getName();
      }
 
      /* interface */
@@ -45,6 +45,17 @@ foreach ($classes as $class_name) {
      if (count($interfaces)) {
          echo " implements ", join(", ", $interfaces);
      }
+     else
+     {
+         /* parent */
+         $parent = $class->getParentClass();
+         if ($parent) {
+             echo " extends ", $parent->getName();
+         }
+     }
+
+
+
      echo " { \n";
 
      $indent .= "\t";


### PR DESCRIPTION
增加Yaf_View_Interface、Yaf_Route_Interface接口语法导出，class为 interface时
，不输出final、abstract等语法字符串。当class implement一个接口时，不输出extends语法字符串。